### PR TITLE
AOT compilation

### DIFF
--- a/TeenyLynx.UCI/TeenyLynx.UCI.csproj
+++ b/TeenyLynx.UCI/TeenyLynx.UCI.csproj
@@ -12,15 +12,17 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Optimized.ToLower())'=='true'">
+    <PublishAot>true</PublishAot>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Configuration>Release</Configuration>
     <SelfContained>true</SelfContained>
-    <PublishSingleFile>true</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <!--In favour of tiered compilation-->
     <PublishReadyToRun>false</PublishReadyToRun>
+    <!--In favour of AOT-->
+    <PublishSingleFile>false</PublishSingleFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
AOT compilation seems to affect negatively the performance, so despite being nice to get a 2.5kb executable for TeenyLynx, I'll
have to discard it for now.
I'd swear I got similar results with Lynx back in the day, with performance being affected by AOT compilation.

```bash
Score of TeenyLynx 27 - aot vs TeenyLynx 26 - ui split: 264 - 345 - 77  [0.441] 686
...      TeenyLynx 27 - aot playing White: 152 - 151 - 40  [0.501] 343
...      TeenyLynx 27 - aot playing Black: 112 - 194 - 37  [0.380] 343
...      White vs Black: 346 - 263 - 77  [0.560] 686
Elo difference: -41.2 +/- 24.7, LOS: 0.1 %, DrawRatio: 11.2 %
SPRT: llr -2.95 (-100.2%), lbound -2.94, ubound 2.94 - H0 was accepted

Player: TeenyLynx 27 - aot
   "Draw by 3-fold repetition": 8
   "Draw by fifty moves rule": 20
   "Draw by insufficient mating material": 49
   "Loss: Black mates": 151
   "Loss: White mates": 194
   "No result": 1
   "Win: Black mates": 112
   "Win: White mates": 152
Player: TeenyLynx 26 - ui split
   "Draw by 3-fold repetition": 8
   "Draw by fifty moves rule": 20
   "Draw by insufficient mating material": 49
   "Loss: Black mates": 112
   "Loss: White mates": 152
   "No result": 1
   "Win: Black mates": 151
   "Win: White mates": 194
Finished match
```