### PR TITLE
Replace `IsDraw()` to avoid checking for stalemate

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -131,7 +131,7 @@ public class MyBot : IChessBot
 
     public /*internal */int NegaMax(int ply, int alpha, int beta, bool isQuiescence)
     {
-        if (_position.IsDraw()) //  IsFiftyMoveDraw() || IsInsufficientMaterial() || IsRepeatedPosition(), no need to check for stalemate
+        if (_position.FiftyMoveCounter >= 100 || _position.IsRepeatedPosition() || _position.IsInsufficientMaterial())
             return 0;
 
         if (!isQuiescence && _timer.MillisecondsElapsedThisTurn > _timePerMove)


### PR DESCRIPTION
Since I check for stalemate at the end of `NegaMax`, potentially saving an invocation to `.GetLegalMoves()` (cutoffs before quiescence, that I'm aware of), it's redundant to do it here (and costly):

It's a lot of tokens, but...

```
Score of TeenyLynx 28 - isdraw vs TeenyLynx 1.1.0: 373 - 271 - 78  [0.571] 722
...      TeenyLynx 28 - isdraw playing White: 190 - 134 - 37  [0.578] 361
...      TeenyLynx 28 - isdraw playing Black: 183 - 137 - 41  [0.564] 361
...      White vs Black: 327 - 317 - 78  [0.507] 722
Elo difference: 49.4 +/- 24.2, LOS: 100.0 %, DrawRatio: 10.8 %
SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted

Player: TeenyLynx 28 - isdraw
   "Draw by 3-fold repetition": 14
   "Draw by adjudication: maximal game length": 1
   "Draw by fifty moves rule": 9
   "Draw by insufficient mating material": 53
   "Draw by stalemate": 1
   "Loss: Black mates": 134
   "Loss: White mates": 137
   "No result": 5
   "Win: Black mates": 183
   "Win: White mates": 190
Player: TeenyLynx 1.1.0
   "Draw by 3-fold repetition": 14
   "Draw by adjudication: maximal game length": 1
   "Draw by fifty moves rule": 9
   "Draw by insufficient mating material": 53
   "Draw by stalemate": 1
   "Loss: Black mates": 183
   "Loss: White mates": 190
   "No result": 5
   "Win: Black mates": 134
   "Win: White mates": 137
Finished match
```