### PR TITLE
Getlegalmoves nonalloc

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -1,5 +1,5 @@
-﻿#define DEBUG
-#define UCI
+﻿//#define DEBUG
+//#define UCI
 
 #pragma warning disable RCS1001, S125 // Add braces (when expression spans over multiple lines) - Tokens are tokens
 


### PR DESCRIPTION
I must be messing something up, search is super slow  with this change

-----
Edit.

Spolier: I was

See https://github.com/lynx-chess/Lynx/pull/301/files

```csharp
        Array.Sort(moves, (moveA, moveB) =>
        {
            var scoreA = ScoreMove(moveA, ply, true, bestMoveTTCandidate);
            var scoreB = ScoreMove(moveB, ply, true, bestMoveTTCandidate);

            return scoreA == scoreB ? 0 : (scoreA > scoreB ? -1 : 1);
        });
```