### PR TITLE
Add min search depth of 3, so that search isn't aborted before

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -137,7 +137,7 @@ public class MyBot : IChessBot
         if (_position.FiftyMoveCounter >= 100 || _position.IsRepeatedPosition() || _position.IsInsufficientMaterial())
             return 0;
 
-        if (!isQuiescence && _timer.MillisecondsElapsedThisTurn > _timePerMove)
+        if (!isQuiescence && ply > 3 && _timer.MillisecondsElapsedThisTurn > _timePerMove)
             throw new();
 
         //if (!isQuiescence && _position.IsInCheck())    // TODO investigate, this makes the bot suggest null moves either other move


### PR DESCRIPTION
Nothing very relevant, by itself at least

```bash
Score of TeenyLynx 39 - min depth vs TeenyLynx 1.2.0: 281 - 289 - 120  [0.494] 690
...      TeenyLynx 39 - min depth playing White: 131 - 151 - 64  [0.471] 346
...      TeenyLynx 39 - min depth playing Black: 150 - 138 - 56  [0.517] 344
...      White vs Black: 269 - 301 - 120  [0.477] 690
Elo difference: -4.0 +/- 23.6, LOS: 36.9 %, DrawRatio: 17.4 %
SPRT: llr -0.625 (-21.2%), lbound -2.94, ubound 2.94
```