### PR TITLE
Add killer moves heuristic

### DIFF
--- a/TeenyLynx.Test/MoveScoreTests.cs
+++ b/TeenyLynx.Test/MoveScoreTests.cs
@@ -25,7 +25,7 @@ public class MoveScoreTest : BaseTest
     {
         var bot = GetBot(fen);
 
-        var allMoves = bot._position.GetLegalMoves().OrderByDescending(move => bot.Score(move, default)).ToList();
+        var allMoves = bot._position.GetLegalMoves().OrderByDescending(move => bot.Score(move, default, default)).ToList();
 
         Assert.AreEqual("e2a6", allMoves[0].ToString()[7..^1]);     // BxB
         Assert.AreEqual("f3f6", allMoves[1].ToString()[7..^1]);     // QxN
@@ -38,7 +38,7 @@ public class MoveScoreTest : BaseTest
 
         foreach (var move in allMoves.Where(move => !move.IsCapture && !move.IsCastles))
         {
-            Assert.AreEqual(0, bot.Score(move, default));
+            Assert.AreEqual(0, bot.Score(move, default, default));
         }
     }
 
@@ -62,9 +62,9 @@ public class MoveScoreTest : BaseTest
     {
         var bot = GetBot(fen);
 
-        var allMoves = bot._position.GetLegalMoves().OrderByDescending(move => bot.Score(move, default)).ToList();
+        var allMoves = bot._position.GetLegalMoves().OrderByDescending(move => bot.Score(move, default, default)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].ToString()[7..^1]);
-        Assert.AreEqual(100_000 + new MyBot().Magic[441 + (int)PieceType.Pawn + 6 * (int)PieceType.Pawn], bot.Score(allMoves[0], default));
+        Assert.AreEqual(100_000 + new MyBot().Magic[441 + (int)PieceType.Pawn + 6 * (int)PieceType.Pawn], bot.Score(allMoves[0], default, default));
     }
 }


### PR DESCRIPTION
917 -> 1014 tokens (+97)
+140 elo

```bash
Score of TeenyLynx 41 - killer moves vs TeenyLynx 1.2.0: 157 - 63 - 26  [0.691] 246
...      TeenyLynx 41 - killer moves playing White: 74 - 34 - 15  [0.663] 123
...      TeenyLynx 41 - killer moves playing Black: 83 - 29 - 11  [0.720] 123
...      White vs Black: 103 - 117 - 26  [0.472] 246
Elo difference: 139.9 +/- 44.3, LOS: 100.0 %, DrawRatio: 10.6 %
SPRT: llr 2.97 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted

Player: TeenyLynx 41 - killer moves
   "Draw by 3-fold repetition": 1
   "Draw by fifty moves rule": 9
   "Draw by insufficient mating material": 15
   "Draw by stalemate": 1
   "Loss: Black mates": 34
   "Loss: White mates": 29
   "No result": 3
   "Win: Black mates": 83
   "Win: White mates": 74
Player: TeenyLynx 1.2.0
   "Draw by 3-fold repetition": 1
   "Draw by fifty moves rule": 9
   "Draw by insufficient mating material": 15
   "Draw by stalemate": 1
   "Loss: Black mates": 83
   "Loss: White mates": 74
   "No result": 3
   "Win: Black mates": 34
   "Win: White mates": 29
Finished match
```