### PR TITLE
Late Move Reduction and Principal Variation Search vs Killer moves

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -239,20 +239,20 @@ public class MyBot : IChessBot
             int evaluation;
             if (movesSearched == 0 || isQuiescence)     // Invokes itself, either Negamax or Quiescence
                 evaluation = -NegaMax(ply + 1, -beta, -alpha, isQuiescence);
-            else
+            else if
             //{
             //// 🔍 Late Move Reduction (LMR)
-            //if (movesSearched >= Configuration.EngineSettings.LMR_FullDepthMoves
-            //    && ply >= Configuration.EngineSettings.LMR_ReductionLimit
-            //    && !_isFollowingPV
-            //    && !isInCheck
-            //    //&& !newPosition.IsInCheck()
-            //    && !move.IsCapture()
-            //    && move.PromotedPiece() == default)
-            //{
-            //    // Search with reduced depth
-            //    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.LMR_DepthReduction, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
-            //}
+            /*if*/ (movesSearched >= 4                  // LMR_FullDepthMoves
+                && ply >= 3                         // LMR_ReductionLimit
+                && !_isFollowingPV
+                && !_position.IsInCheck()
+                //&& !newPosition.IsInCheck()
+                && !move.IsCapture
+                && !move.IsPromotion)
+            {
+                // Search with reduced depth
+                evaluation = -NegaMax(ply + 1 + 1, -alpha - 1, -alpha, isQuiescence);   // +1: LMR_DepthReduction
+            }
             //else
             //{
             //    // Ensuring full depth search takes place
@@ -262,18 +262,18 @@ public class MyBot : IChessBot
             //if (evaluation > alpha)
             //{
             // 🔍 Principal Variation Search (PVS)
-            if (!bestMove.IsNull)
-            {
-                // Optimistic search, validating that the rest of the moves are worse than bestmove.
-                // It should produce more cutoffs and therefore be faster.
-                // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
+            //if (!bestMove.IsNull)
+            //{
+            //    // Optimistic search, validating that the rest of the moves are worse than bestmove.
+            //    // It should produce more cutoffs and therefore be faster.
+            //    // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 
-                // Search with full depth but narrowed score bandwidth
-                evaluation = -NegaMax(ply + 1, -alpha - 1, -alpha, isQuiescence);
+            //    // Search with full depth but narrowed score bandwidth
+            //    evaluation = -NegaMax(ply + 1, -alpha - 1, -alpha, isQuiescence);
 
-                if (evaluation > alpha && evaluation < beta)    // Hipothesis invalidated -> search with full depth and full score bandwidth
-                    evaluation = -NegaMax(ply + 1, -beta, -alpha, isQuiescence);
-            }
+            //    if (evaluation > alpha && evaluation < beta)    // Hipothesis invalidated -> search with full depth and full score bandwidth
+            //        evaluation = -NegaMax(ply + 1, -beta, -alpha, isQuiescence);
+            //}
             else
                 evaluation = -NegaMax(ply + 1, -beta, -alpha, isQuiescence);
             //}


### PR DESCRIPTION
LMR and PVS together can't dream of beating killing move heuristic
```
Score of TeenyLynx 48 - pvs + lmr vs TeenyLynx 41 - killer moves: 23 - 111 - 11  [0.197] 145
...      TeenyLynx 48 - pvs + lmr playing White: 17 - 49 - 7  [0.281] 73
...      TeenyLynx 48 - pvs + lmr playing Black: 6 - 62 - 4  [0.111] 72
...      White vs Black: 79 - 55 - 11  [0.583] 145
Elo difference: -244.6 +/- 68.5, LOS: 0.0 %, DrawRatio: 7.6 %
SPRT: llr -2.95 (-100.1%), lbound -2.94, ubound 2.94 - H0 was accepted
```