### PR TITLE
Add killer moves heuristic and aspiration window search

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -80,7 +80,7 @@ public class MyBot : IChessBot
             int msSpentPerDepth = 0;
             do
             {
-                //AspirationWindows_SearchAgain:
+                AspirationWindows_SearchAgain:
                 _isFollowingPV = true;
 #if DEBUG
                 bestEvaluation = NegaMax(0, alpha, beta, false);
@@ -89,20 +89,20 @@ public class MyBot : IChessBot
 #endif
                 isMateDetected = Abs(bestEvaluation) > 27_000;
 
-                //if (!isMateDetected && ((bestEvaluation <= alpha) || (bestEvaluation >= beta)))
-                //{
-                alpha = short.MinValue;   // We fell outside the window, so try again with a
-                beta = short.MaxValue;    // full-width window (and the same depth).
+                if (!isMateDetected && ((bestEvaluation <= alpha) || (bestEvaluation >= beta)))
+                {
+                    alpha = short.MinValue;   // We fell outside the window, so try again with a
+                    beta = short.MaxValue;    // full-width window (and the same depth).
 
-                //    goto AspirationWindows_SearchAgain;
-                //}
+                    goto AspirationWindows_SearchAgain;
+                }
 
                 bestMove = _pVTable[0];
 #if DEBUG || UCI
                 Console.WriteLine($"info depth {_targetDepth} score {(isMateDetected ? "mate 99" : $"cp {bestEvaluation}")} nodes {_nodes} nps {Convert.ToInt64(Clamp(_nodes / ((0.001 * _timer.MillisecondsElapsedThisTurn) + 1), 0, long.MaxValue))} time {_timer.MillisecondsElapsedThisTurn} pv {string.Join(' ', _pVTable.TakeWhile(m => !m.IsNull).Select(m => m.ToString()[7..^1]))}");
 #endif
-                //alpha = bestEvaluation - 50;
-                //beta = bestEvaluation + 50;
+                alpha = bestEvaluation - 50;
+                beta = bestEvaluation + 50;
 
                 //Array.Copy(_killerMoves, _previousKillerMoves, _killerMoves.Length);
 

--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -256,10 +256,12 @@ public class MyBot : IChessBot
                 bestMove = _pVTable[pvIndex] = move;
 
                 #region CopyPVTableMoves
+
                 if (_pVTable[nextPvIndex].IsNull)
-                    Array.Clear(_pVTable, pvIndex + 1, _pVTable.Length - pvIndex + 1);
+                    Array.Clear(_pVTable, pvIndex + 1, _pVTable.Length - pvIndex - 1);
                 else
-                    Array.Copy(_pVTable, nextPvIndex, _pVTable, pvIndex + 1, 128 - ply - 1);
+                    Array.Copy(_pVTable, nextPvIndex, _pVTable, pvIndex + 1, 127 - ply);    // 128 - ply - 1
+
                 #endregion
 
                 // 🔍 History moves

--- a/TeenyLynx.Test/MoveScoreTests.cs
+++ b/TeenyLynx.Test/MoveScoreTests.cs
@@ -25,7 +25,7 @@ public class MoveScoreTest : BaseTest
     {
         var bot = GetBot(fen);
 
-        var allMoves = bot._position.GetLegalMoves().OrderByDescending(move => bot.Score(move, default)).ToList();
+        var allMoves = bot._position.GetLegalMoves().OrderByDescending(move => bot.Score(move, default, default)).ToList();
 
         Assert.AreEqual("e2a6", allMoves[0].ToString()[7..^1]);     // BxB
         Assert.AreEqual("f3f6", allMoves[1].ToString()[7..^1]);     // QxN
@@ -38,7 +38,7 @@ public class MoveScoreTest : BaseTest
 
         foreach (var move in allMoves.Where(move => !move.IsCapture && !move.IsCastles))
         {
-            Assert.AreEqual(0, bot.Score(move, default));
+            Assert.AreEqual(0, bot.Score(move, default, default));
         }
     }
 
@@ -62,9 +62,9 @@ public class MoveScoreTest : BaseTest
     {
         var bot = GetBot(fen);
 
-        var allMoves = bot._position.GetLegalMoves().OrderByDescending(move => bot.Score(move, default)).ToList();
+        var allMoves = bot._position.GetLegalMoves().OrderByDescending(move => bot.Score(move, default, default)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].ToString()[7..^1]);
-        Assert.AreEqual(100_000 + new MyBot().Magic[441 + (int)PieceType.Pawn + 6 * (int)PieceType.Pawn], bot.Score(allMoves[0], default));
+        Assert.AreEqual(100_000 + new MyBot().Magic[441 + (int)PieceType.Pawn + 6 * (int)PieceType.Pawn], bot.Score(allMoves[0], default, default));
     }
 }


### PR DESCRIPTION
Combines #5 and #8 

[run in progress, but will planning to merge it anyway due to code submission deadline for first community tournament]

1'+0
```bash
Score of TeenyLynx 49 - killer + asp vs TeenyLynx 41 - killer: 337 - 283 - 90  [0.538] 710
...      TeenyLynx 49 - killer + asp playing White: 163 - 138 - 54  [0.535] 355
...      TeenyLynx 49 - killer + asp playing Black: 174 - 145 - 36  [0.541] 355
...      White vs Black: 308 - 312 - 90  [0.497] 710
Elo difference: 26.5 +/- 23.9, LOS: 98.5 %, DrawRatio: 12.7 %
SPRT: llr 1.44 (49.1%), lbound -2.94, ubound 2.94
```
15''+0
```
Score of TeenyLynx 49 - killer + asp vs TeenyLynx 41 - killer: 330 - 280 - 90  [0.536] 700
...      TeenyLynx 49 - killer + asp playing White: 159 - 137 - 54  [0.531] 350
...      TeenyLynx 49 - killer + asp playing Black: 171 - 143 - 36  [0.540] 350
...      White vs Black: 302 - 308 - 90  [0.496] 700
Elo difference: 24.9 +/- 24.1, LOS: 97.9 %, DrawRatio: 12.9 %
SPRT: llr 1.32 (44.8%), lbound -2.94, ubound 2.94
```