### PR TITLE
Extend depth on check

### DIFF
--- a/TeenyLynx.Test/StaticEvaluationTests.cs
+++ b/TeenyLynx.Test/StaticEvaluationTests.cs
@@ -42,7 +42,7 @@ public class StaticEvaluationTests : BaseTest
         var teenyLynx = GetBot(fen);
 
         // Act
-        var staticEval = teenyLynx.NegaMax(0, int.MinValue, beta: int.MinValue, isQuiescence: true);    // Causing beta cutoff and getting static eval back
+        var staticEval = teenyLynx.NegaMax(1, 0, int.MinValue, beta: int.MinValue, isQuiescence: true);    // Causing beta cutoff and getting static eval back
 
         // Assert
         Assert.AreEqual(expectedEval, staticEval);


### PR DESCRIPTION
It took me a while to figure out that `targetDepth` needs to be passed around for this implementation.

60''
```
Score of TeenyLynx 55 - extend depth on check vs TeenyLynx 1.3.0: 896 - 839 - 295  [0.514] 2030
...      TeenyLynx 55 - extend depth on check playing White: 454 - 422 - 140  [0.516] 1016
...      TeenyLynx 55 - extend depth on check playing Black: 442 - 417 - 155  [0.512] 1014
...      White vs Black: 871 - 864 - 295  [0.502] 2030
Elo difference: 9.8 +/- 14.0, LOS: 91.4 %, DrawRatio: 14.5 %
SPRT: llr 0.936 (31.8%), lbound -2.94, ubound 2.94
```

15''
```
Score of TeenyLynx 55 - extend-depth-on-check vs TeenyLynx 1.3.0: 910 - 804 - 306  [0.526] 2020
...      TeenyLynx 55 - extend-depth-on-check playing White: 443 - 411 - 156  [0.516] 1010
...      TeenyLynx 55 - extend-depth-on-check playing Black: 467 - 393 - 150  [0.537] 1010
...      White vs Black: 836 - 878 - 306  [0.490] 2020
Elo difference: 18.2 +/- 14.0, LOS: 99.5 %, DrawRatio: 15.1 %
SPRT: llr 2.61 (88.7%), lbound -2.94, ubound 2.94
```