### PR TITLE
Fix move ordering

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -285,7 +285,7 @@ public class MyBot : IChessBot
         {
             _isScoringPV = false;
 
-            return 20_000;
+            return 1_000_000;
         }
 
         if (move.IsCapture)


### PR DESCRIPTION
Use PV move first, as it was intended to be

15'', local run
```
Score of TeenyLynx 56 - fix pv move order vs TeenyLynx 1.3.0: 534 - 603 - 185  [0.474] 1322
...      TeenyLynx 56 - fix pv move order playing White: 286 - 279 - 96  [0.505] 661
...      TeenyLynx 56 - fix pv move order playing Black: 248 - 324 - 89  [0.443] 661
...      White vs Black: 610 - 527 - 185  [0.531] 1322
Elo difference: -18.2 +/- 17.4, LOS: 2.0 %, DrawRatio: 14.0 %
SPRT: llr -2.95 (-100.1%), lbound -2.94, ubound 2.94 - H0 was accepted
```

30'' local run
```
Score of TeenyLynx 62 - pv move ordering vs TeenyLynx 1.4.0: 341 - 350 - 134  [0.495] 825
...      TeenyLynx 62 - pv move ordering playing White: 165 - 177 - 71  [0.485] 413
...      TeenyLynx 62 - pv move ordering playing Black: 176 - 173 - 63  [0.504] 412
...      White vs Black: 338 - 353 - 134  [0.491] 825
Elo difference: -3.8 +/- 21.7, LOS: 36.6 %, DrawRatio: 16.2 %
SPRT: llr -0.717 (-24.4%), lbound -2.94, ubound 2.94
```

60'' run
```
Score of TeenyLynx 62 - pv move ordering vs TeenyLynx 1.4.0: 633 - 619 - 266  [0.505] 1518
...      TeenyLynx 62 - pv move ordering playing White: 282 - 335 - 142  [0.465] 759
...      TeenyLynx 62 - pv move ordering playing Black: 351 - 284 - 124  [0.544] 759
...      White vs Black: 566 - 686 - 266  [0.460] 1518
Elo difference: 3.2 +/- 15.9, LOS: 65.4 %, DrawRatio: 17.5 %
SPRT: llr -0.274 (-9.3%), lbound -2.94, ubound 2.94
```

Big brother one isn't going great either
1'+1''
```
Score of TeenyLynx 62 - pv move ordering vs TeenyLynx 1.4.0: 633 - 619 - 266  [0.505] 1518
...      TeenyLynx 62 - pv move ordering playing White: 282 - 335 - 142  [0.465] 759
...      TeenyLynx 62 - pv move ordering playing Black: 351 - 284 - 124  [0.544] 759
...      White vs Black: 566 - 686 - 266  [0.460] 1518
Elo difference: 3.2 +/- 15.9, LOS: 65.4 %, DrawRatio: 17.5 %
SPRT: llr -0.274 (-9.3%), lbound -2.94, ubound 2.94
```