### PR TITLE
Simplify time management 

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -48,8 +48,7 @@ public class MyBot : IChessBot
         Array.Clear(_killerMoves);
         //Array.Clear(_historyMoves);
 
-        int movesToGo = 100 - board.PlyCount >> 1,
-            targetDepth = 1,
+        int targetDepth = 1,
             alpha = -32_768,    //  short.MinValue
             beta = 32_767       //  short.MaxValue+
 #if DEBUG

--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -60,8 +60,7 @@ public class MyBot : IChessBot
 
         #region Time management
 
-        movesToGo = Clamp(movesToGo, 40, 100);
-        _timePerMove = Clamp(timer.MillisecondsRemaining / movesToGo, 1, 2000);
+        _timePerMove = timer.MillisecondsRemaining / 30;
 
 #if DEBUG || UCI
         _nodes = 0;


### PR DESCRIPTION
Simplify time management to `_timePerMove = timer.MillisecondsRemaining / 30`

Equal results on 60'
```
Score of TeenyLynx 66 - simplify tm vs TeenyLynx 1.4.0: 919 - 890 - 358  [0.507] 2167
...      TeenyLynx 66 - simplify tm playing White: 442 - 468 - 174  [0.488] 1084
...      TeenyLynx 66 - simplify tm playing Black: 477 - 422 - 184  [0.525] 1083
...      White vs Black: 864 - 945 - 358  [0.481] 2167
Elo difference: 4.6 +/- 13.4, LOS: 75.2 %, DrawRatio: 16.5 %
SPRT: llr -0.0752 (-2.6%), lbound -2.94, ubound 2.94
```

Slightly better results on 10'
```
Score of TeenyLynx 66 - simplify tm vs TeenyLynx 1.4.0: 1550 - 1412 - 484  [0.520] 3446
...      TeenyLynx 66 - simplify tm playing White: 851 - 654 - 218  [0.557] 1723
...      TeenyLynx 66 - simplify tm playing Black: 699 - 758 - 266  [0.483] 1723
...      White vs Black: 1609 - 1353 - 484  [0.537] 3446
Elo difference: 13.9 +/- 10.8, LOS: 99.4 %, DrawRatio: 14.0 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted
```

Since less tokens...